### PR TITLE
Fix - eSewa received amount error for IPN validity

### DIFF
--- a/includes/includes/class-wc-gateway-esewa-ipn-handler.php
+++ b/includes/includes/class-wc-gateway-esewa-ipn-handler.php
@@ -101,6 +101,16 @@ class WC_Gateway_eSewa_IPN_Handler extends WC_Gateway_eSewa_Response {
 		$order_id    = isset( $_REQUEST['oid'] ) ? wc_clean( wp_unslash( $_REQUEST['oid'] ) ) : ''; // WPCS: input var ok, CSRF ok.
 		$transaction = isset( $_REQUEST['refId'] ) ? wc_clean( wp_unslash( $_REQUEST['refId'] ) ) : ''; // WPCS: input var ok, CSRF ok.
 
+		// Fix esewa amount validation.
+		if ( isset( $_REQUEST['key'] ) ) {
+			$order = $this->get_esewa_order( $order_id, wc_clean( wp_unslash( $_REQUEST['key'] ) ) ); // WPCS: input var ok, CSRF ok.
+
+			if ( number_format( $order->get_total(), 2, '.', '' ) !== number_format( $amount, 2, '.', '' ) ) {
+				WC_Gateway_eSewa::log( 'Amount alert: eSewa amount do not match (sent "' . $order->get_total() . '" | returned "' . $amount . '").', 'alert' );
+				$amount = $order->get_total();
+			}
+		}
+
 		// Send back post vars to esewa.
 		$params = array(
 			'body'        => array(


### PR DESCRIPTION
Currently eSewa is not sending total paid amount including tax, service charge and delivery chare. Instead it is sending only product total amount in the response parameter `amt` of success URL. 

While contacting eSewa merchant team, they told it was not intentionally plan but was caused due to server upgrade. They are working for the patch and will be deliverd within 1-2 week. 